### PR TITLE
Add missing kettle statuses

### DIFF
--- a/hwkitchen/enums/kettle_status.py
+++ b/hwkitchen/enums/kettle_status.py
@@ -3,6 +3,8 @@ from enum import Enum
 
 class KettleStatus(Enum):
     ON = "on"
+    HEATING = "heating"
     HEATING_TO_TARGET = "heating_to_target"
+    COOLING_TO_TARGET = "cooling_to_target"
     FINISHED_HEATING_TO_TARGET = "finished_heating_to_target"
     KEEPING_WARM = "keeping_warm"


### PR DESCRIPTION
Thank you very much for this project! I bought this kettle a few days ago and was eager to integrate it with my home automation (which I did: https://gist.github.com/ghys/ea549402e88876e6daa3ac9aa403ec9f)

I have found a few statuses that are not in the KettleStatus enum.

```
ValueError: 'heating' is not a valid KettleStatus

ValueError: 'cooling_to_target' is not a valid KettleStatus
```
These are encountered when you enable the "boil before target" function and start.